### PR TITLE
Add survey group link to home page

### DIFF
--- a/data/pages.yml
+++ b/data/pages.yml
@@ -8,15 +8,12 @@ main:
     -   name: Calendar
         url: /calendar/
         newtab: 0
-    -   name: Submit
-        url: /submit/
-        newtab: 0
     -   name: Data Catalog
         url: /catalog/
         newtab: 0
-    -   name: GitHub
-        url: https://github.com/HarvardOpenData/HarvardOpenData.github.io
-        newtab: 1
+    -   name: Survey Group
+        url: /demographics/
+        newtab: 0
     -   name: Blog
         url: https://medium.com/harvard-open-data-project
         newtab: 1


### PR DESCRIPTION
I deleted a few of the links from the home page and added the survey group link. I don't think the GitHub is important enough to link from the home page and I don't think that the submit datasets page actually doesn't anything right now. 