### PR TITLE
adjusted src for bootstrap to use https instead of http

### DIFF
--- a/templates/_includes/scripts.html
+++ b/templates/_includes/scripts.html
@@ -3,7 +3,7 @@
 <script>window.jQuery || document.write('<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js"><\/script>')</script>
 
 <!-- Bootstrap -->
-<script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
 
 <!-- Custom scripts for each page -->
 {% for script in page.scripts %}


### PR DESCRIPTION
Currently certain [pages](https://hodp.org/projects/) on the production site reliant on Bootstrap do not function properly because the latest browsers do not allow pages served over HTTPS to fetch other content over HTTP as a security policy. In our case, we're attempting to fetch a minified Bootstrap file over HTTP instead of HTTPS, and because our site uses HTTPS, most web browsers will block this request. 

The fix below addresses this by merely changing the protocol used to fetch Bootstrap accordingly.