### PR TITLE
Enable incremental builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,3 +3,6 @@
   command = "npm run build"
   functions = "functions"
   publish = "public"
+
+[[plugins]]
+package = "netlify-plugin-gatsby-cache"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9913,6 +9913,7 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
       "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
       "requires": {
         "cross-spawn": "^7.0.1"
       },
@@ -9921,6 +9922,7 @@
           "version": "7.0.3",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
           "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
           "requires": {
             "path-key": "^3.1.0",
             "shebang-command": "^2.0.0",
@@ -9930,12 +9932,14 @@
         "path-key": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
         },
         "shebang-command": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
           "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
           "requires": {
             "shebang-regex": "^3.0.0"
           }
@@ -9943,12 +9947,14 @@
         "shebang-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
         },
         "which": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -19412,6 +19418,12 @@
           }
         }
       }
+    },
+    "netlify-plugin-gatsby-cache": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/netlify-plugin-gatsby-cache/-/netlify-plugin-gatsby-cache-0.3.2.tgz",
+      "integrity": "sha512-Ssj2af0DliY70u8MmkDN25cpDk2/jW1aVZxPdljdm17oNwAIQcB17BF86RlW0ikdQ94KGHfaJymjVUZM7K3hPA==",
+      "dev": true
     },
     "netlify-redirect-parser": {
       "version": "2.5.0",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9909,6 +9909,52 @@
         "warning": "^4.0.3"
       }
     },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "cross-fetch": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",

--- a/web/package.json
+++ b/web/package.json
@@ -28,7 +28,6 @@
     "algoliasearch": "^4.6.0",
     "caniuse-lite": "^1.0.30001137",
     "chart.js": "^2.9.3",
-    "cross-env": "^7.0.3",
     "d3-ease": "^1.0.7",
     "d3-fetch": "^1.2.0",
     "d3-format": "^1.4.5",
@@ -82,6 +81,7 @@
     "theme-ui": "^0.3.1"
   },
   "devDependencies": {
+    "cross-env": "^7.0.3",
     "eslint": "^6.8.0",
     "eslint-config-standard": "^14.1.1",
     "eslint-config-standard-react": "^9.2.0",
@@ -90,6 +90,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-react": "^7.21.2",
     "eslint-plugin-standard": "^4.0.1",
+    "netlify-plugin-gatsby-cache": "^0.3.2",
     "prettier-eslint-cli": "^5.0.0",
     "prop-types": "^15.7.2"
   }

--- a/web/package.json
+++ b/web/package.json
@@ -42,7 +42,7 @@
     "dot-prop": "^5.3.0",
     "dotenv": "^8.2.0",
     "firebase": "^8.0.0",
-    "gatsby": "^2.24.65",
+    "gatsby": "^2.26.0",
     "gatsby-plugin-client-side-redirect": "^1.1.0",
     "gatsby-plugin-env-variables": "^2.0.0",
     "gatsby-plugin-firebase": "^0.2.0-beta.4",

--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,7 @@
     "node": "10.x"
   },
   "scripts": {
-    "build": "gatsby build",
+    "build": "cross-env GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES=true gatsby build --log-pages",
     "deploy": "npm run now-deploy",
     "develop": "gatsby develop",
     "empty-cache": "gatsby clean",
@@ -28,6 +28,7 @@
     "algoliasearch": "^4.6.0",
     "caniuse-lite": "^1.0.30001137",
     "chart.js": "^2.9.3",
+    "cross-env": "^7.0.3",
     "d3-ease": "^1.0.7",
     "d3-fetch": "^1.2.0",
     "d3-format": "^1.4.5",


### PR DESCRIPTION
Adds the `netlify-plugin-gatsby-cache` Netlify plugin. During the build process, Gatsby should now only rebuild pages whose corresponding content in Sanity have been modified.

### New dependencies
- `cross-env` since it was recommended to avoid cross-platform issues with env vars
- `netlify-plugin-gatsby-cache`: the magic plugin

### Testing
By running `npm run build` under `web/`, Gatsby will first build every page as usual. Then, by making a meaningful change to any content in Sanity, you may verify that on subsequent builds Gatsby will only update the necessary pages.