### PR TITLE
Enable netlify deploy button on sanity dashboard

### DIFF
--- a/studio/dashboardConfig.js
+++ b/studio/dashboardConfig.js
@@ -3,7 +3,7 @@ export default {
     {
       name: "netlify",
       options: {
-        title: "Netlify Deploys (not fully configured yet)",
+        title: "Netlify Deploys",
         sites: [
           {
             title: "Website",


### PR DESCRIPTION
Removing `"(not fully configured yet)"` because deploy button now works