### PR TITLE
Update to use firebase admin list

### DIFF
--- a/web/src/components/predictions/leaderboard.js
+++ b/web/src/components/predictions/leaderboard.js
@@ -10,7 +10,7 @@ const Leaderboard = ({ user }) => {
   const [admin, adminLoading, adminError] = useObject(
     firebase.database().ref("admins/" + user.uid)
   );
-  
+
   const [names, namesLoading, namesError] = useObject(
     firebase.database().ref("public")
   );
@@ -102,7 +102,7 @@ const Leaderboard = ({ user }) => {
         </Box>
       )}
       <Spacer height={3} />
-      {/*if user.uid matches below, then a button is rendered that allows for updating all scores*/}
+      {/*if user.uid matches any admin uid, then a button is rendered that allows for updating all scores*/}
       {!adminError && !adminLoading && admin && <UpdateScore />}
     </div>
   );

--- a/web/src/components/predictions/leaderboard.js
+++ b/web/src/components/predictions/leaderboard.js
@@ -7,6 +7,10 @@ import UpdateScore from "./update-score";
 
 // generate leaderboard
 const Leaderboard = ({ user }) => {
+  const [admin, adminLoading, adminError] = useObject(
+    firebase.database().ref("admins/" + user.uid)
+  );
+  
   const [names, namesLoading, namesError] = useObject(
     firebase.database().ref("public")
   );
@@ -99,7 +103,7 @@ const Leaderboard = ({ user }) => {
       )}
       <Spacer height={3} />
       {/*if user.uid matches below, then a button is rendered that allows for updating all scores*/}
-      {user.uid === process.env.ADMIN_USER && <UpdateScore />}
+      {!adminError && !adminLoading && admin && <UpdateScore />}
     </div>
   );
 };


### PR DESCRIPTION
Before, to update the leaderboard list, you had to be on your local account or have your user id be set as the admin as a environment variable.

Now, we check firebase for a list of admins and if you are an admin account, you can see the update button live on the website.

![image](https://user-images.githubusercontent.com/12895833/213574468-471d5c0f-e5aa-45da-8e50-56bb86edba45.png)
